### PR TITLE
Fix file name extension not stored

### DIFF
--- a/src/Concerns/AttachmentCreator.php
+++ b/src/Concerns/AttachmentCreator.php
@@ -37,7 +37,7 @@ trait AttachmentCreator
      */
     public function storeFile(UploadedFile $file, string $disk)
     {
-        return $file->storeAs('/', Str::uuid(), [
+        return $file->storeAs('/', Str::uuid().'.'.$file->getClientOriginalExtension(), [
             'disk' => $disk
         ]);
     }


### PR DESCRIPTION
FIle extension not saved when using `create` method

```
$attachment = $this->create(request()->file('thumbnail_image'), [
            'disk' => 'thumbnail',
            'type' => 'thumbnail',
            'title' => 'This is File Title',
        ]);
```